### PR TITLE
Retry Kinesis PutRecords that failed

### DIFF
--- a/lib/post-kinesis.js
+++ b/lib/post-kinesis.js
@@ -22,6 +22,7 @@
 
 // Modules
 var AWS = require('aws-sdk');
+var retry = require('retry');
 
 // Default values
 var defaultValues = {
@@ -67,6 +68,36 @@ exports.create = function(target, options) {
 //********
 // This function sends messages to Amazon Kinesis
 exports.send = function(service, target, records, callback) {
-  var entries = records.map(function(record) { return { PartitionKey: record.key, Data: record.data }; })
-  service.putRecords({ StreamName: target.destination, Records: entries }, callback);
+  var entries = records.map(function(record) { return { PartitionKey: record.key, Data: record.data }; });
+  this.putRecordsWithRetry(service, { StreamName: target.destination, Records: entries }, callback);
+};
+
+this.putRecordsWithRetry = function(service, request, callback)
+{
+  var operation = retry.operation({
+    retries: 10,
+    factor: 2,
+    minTimeout: 10,
+    maxTimeout: 10000
+  });
+
+  operation.attempt(function(current) {
+    var response = service.putRecords(request, function() {
+      if (response && response.FailedRecordCount && response.FailedRecordCount == 0)
+        return;
+      if (response && response.Records)
+      {
+        var failed = response.Records.map(function(record) { return record.ErrorCode != null; } );
+        request.Records = request.Records.filter(function(record, index) { return failed[index]; });
+        var err = new Error(response.Records[0].ErrorCode);
+        if (operation.retry())
+          return;
+      }
+      callback(err ? operation.mainError() : null);
+    });
+  });
+};
+
+Array.prototype.contains = function(element){
+  return this.indexOf(element) > -1;
 };

--- a/lib/post-sns.js
+++ b/lib/post-sns.js
@@ -46,8 +46,8 @@ exports.destinationRegex = /^arn:aws:sns:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:[a-zA-Z0-
 // Limits for message publication
 exports.limits = {
   maxRecords: Number.MAX_VALUE,  // No limit on number of records, we collapse them in a single value
-  maxSize: 256*1024,             // Amazon SNS only accepts up to 256KiB per message
-  maxUnitSize: 256*1024,         // Amazon SNS only accepts up to 256KiB per message
+  maxSize: 250*1024,             // Amazon SNS only accepts up to 256KiB per message
+  maxUnitSize: 250*1024,         // Amazon SNS only accepts up to 256KiB per message
   includeKey: false,             // Records will not include the key
   listOverhead: 14,              // Records are put in a JSON object "{"Records":[]}"
   recordOverhead: 0,             // Records are just serialized


### PR DESCRIPTION
`post-kinesis.js` now detects failed puts (e.g. `ProvisionedThroughputExceededException`) and retries with backoff (`npm install retry`)
see _Handling Failures When Using PutRecords_ in https://docs.aws.amazon.com/streams/latest/dev/developing-producers-with-sdk.html
