### PR TITLE
Message too large for SNS was causing Lambda to fail

### DIFF
--- a/fanout.js
+++ b/fanout.js
@@ -63,7 +63,7 @@ function postToService(serviceReference, target, records, stats, callback) {
     var size = record.size + (includeKey ? Buffer.byteLength(record.key) : 0);
 		if((size + listOverhead + recordOverhead) > maxUnitSize) {
 			console.error("Record too large to be pushed to target '" + target.id + "' of type '" + target.type + "':\n", JSON.stringify(record));
-			errors.push(new Error("Record too large, was removed"));
+			//errors.push(new Error("Record too large, was removed")); // NOTE: This causes lambda (context) to fail, which in this case, we don't want to do
 			return false;
 		} else {
 			return true;


### PR DESCRIPTION
Message too large for SNS was causing Lambda to fail, retry same batch, hold up shard. 
Don't push error to list, just log it and move on.

@alexquintero , this fixed the fanout failing problem we were looking at last night.
I didn't do any additional investigation into the too large messages.