### PR TITLE
Buffer.from() port (deprecation), merged from fork, and fixed Kinesis put retry code

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The `deploy` command creates the `fanout function` and supporting resources (AWS
 * `--exec-role <fanoutRole>` (optional) specify the AWS IAM Role to use for the `fanout function`. The role is created if it does not exist.
     * You can specify the role by ARN and avoid role detection and creation by using `--exec-role-arn <arn:aws:iam::0123456789abcdef::role/fanoutRole>`
 * `--memory <128>` (optional, default 128) specify the amount of memory (in MiB) to use for the function
-* `--runtime <nodejs8.10>` (optional, default `nodejs8.10`) specify the runtime environment for the Lambda function
+* `--runtime <nodejs10.x>` (optional, default `nodejs10.x`) specify the runtime environment for the Lambda function
 * `--timeout <30>` (optional, default 30) specify the timeout of the function (in seconds)
 
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The `deploy` command creates the `fanout function` and supporting resources (AWS
 * `--exec-role <fanoutRole>` (optional) specify the AWS IAM Role to use for the `fanout function`. The role is created if it does not exist.
     * You can specify the role by ARN and avoid role detection and creation by using `--exec-role-arn <arn:aws:iam::0123456789abcdef::role/fanoutRole>`
 * `--memory <128>` (optional, default 128) specify the amount of memory (in MiB) to use for the function
-* `--runtime <nodejs4.3>` (optional, default `nodejs4.3`) specify the runtime environment for the Lambda function
+* `--runtime <nodejs8.10>` (optional, default `nodejs8.10`) specify the runtime environment for the Lambda function
 * `--timeout <30>` (optional, default 30) specify the timeout of the function (in seconds)
 
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The `deploy` command creates the `fanout function` and supporting resources (AWS
 * `--exec-role <fanoutRole>` (optional) specify the AWS IAM Role to use for the `fanout function`. The role is created if it does not exist.
     * You can specify the role by ARN and avoid role detection and creation by using `--exec-role-arn <arn:aws:iam::0123456789abcdef::role/fanoutRole>`
 * `--memory <128>` (optional, default 128) specify the amount of memory (in MiB) to use for the function
+* `--runtime <nodejs4.3>` (optional, default `nodejs4.3`) specify the runtime environment for the Lambda function
 * `--timeout <30>` (optional, default 30) specify the timeout of the function (in seconds)
 
 

--- a/cli/functions.sh
+++ b/cli/functions.sh
@@ -129,7 +129,7 @@ function readFunctionConfigParams {
   MEMORY_SIZE=128
   TIMEOUT=30
   SECURITY_GROUPS=
-  RUNTIME=nodejs8.10
+  RUNTIME=nodejs10.x
 
   while [ $# -ne 0 ]; do
     CODE=$1

--- a/cli/functions.sh
+++ b/cli/functions.sh
@@ -285,7 +285,7 @@ function deployFanout {
       fi
     fi
 
-    FUNCTION_ARN=$(aws lambda "create-function" --function-name $FUNCTION_NAME --runtime nodejs4.3 --description "This is an Amazon Kinesis and Amazon DynamoDB Streams fanout function, look at $TABLE_NAME DynamoDB table for configuration" --handler fanout.handler --role $EXEC_ROLE_ARN --memory-size $MEMORY_SIZE --timeout $TIMEOUT --zip-file fileb://fanout.zip ${VPC_PARAMS[@]} --query 'FunctionArn' --output text ${CLI_PARAMS[@]})
+    FUNCTION_ARN=$(aws lambda "create-function" --function-name $FUNCTION_NAME --runtime nodejs8.10 --description "This is an Amazon Kinesis and Amazon DynamoDB Streams fanout function, look at $TABLE_NAME DynamoDB table for configuration" --handler fanout.handler --role $EXEC_ROLE_ARN --memory-size $MEMORY_SIZE --timeout $TIMEOUT --zip-file fileb://fanout.zip ${VPC_PARAMS[@]} --query 'FunctionArn' --output text ${CLI_PARAMS[@]})
     if [ -z "${FUNCTION_ARN}" ]; then
       echo "Unable to create specified AWS Lambda Function '${FUNCTION_NAME}'" 1>&2
       cd "$OLD"

--- a/cli/functions.sh
+++ b/cli/functions.sh
@@ -129,7 +129,7 @@ function readFunctionConfigParams {
   MEMORY_SIZE=128
   TIMEOUT=30
   SECURITY_GROUPS=
-  RUNTIME=nodejs4.3
+  RUNTIME=nodejs8.10
 
   while [ $# -ne 0 ]; do
     CODE=$1

--- a/cli/functions.sh
+++ b/cli/functions.sh
@@ -268,12 +268,14 @@ function deployFanout {
         aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole ${CLI_PARAMS[@]}
         aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole ${CLI_PARAMS[@]}
         aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole ${CLI_PARAMS[@]}
+        aws iam put-role-policy --role-name $EXEC_ROLE_NAME --policy-name Metrics --policy-document '{"Version": "2012-10-17", "Statement": [{"Action": ["cloudwatch:PutMetricData"], "Resource": ["*"], "Effect": "Allow", "Sid": ""}]}' ${CLI_PARAMS[@]}
         aws iam put-role-policy --role-name $EXEC_ROLE_NAME --policy-name ReadConfiguration --policy-document '{"Version": "2012-10-17", "Statement": [{"Action": ["dynamodb:Query"], "Resource": ["'$TABLE_ARN'"], "Effect": "Allow"}]}' ${CLI_PARAMS[@]}
         aws iam put-role-policy --role-name $EXEC_ROLE_NAME --policy-name PublishData --policy-document '{"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole","kinesis:PutRecord*","sqs:SendMessage*","sns:Publish","firehose:PutRecordBatch","iot:Publish*","lambda:Invoke*","es:ESHttpPost"], "Resource": ["*"], "Effect": "Allow", "Sid": ""}]}' ${CLI_PARAMS[@]}
         echo "Created AWS IAM Role $EXEC_ROLE_NAME with ARN: $EXEC_ROLE_ARN"
         echo "... Sleeping for 10 seconds to ensure the role has been propagated ..."
         sleep 10
       fi
+
     else
       EXEC_ROLE_NAME=$( echo "$EXEC_ROLE_ARN" | sed -E -n 's#^arn:aws:iam::role/([a-zA-Z0-9+=,.@_-]{1,64})$#\1#p' )
       if [ ! -z "$EXEC_ROLE_NAME" ]; then

--- a/cli/functions.sh
+++ b/cli/functions.sh
@@ -129,6 +129,7 @@ function readFunctionConfigParams {
   MEMORY_SIZE=128
   TIMEOUT=30
   SECURITY_GROUPS=
+  RUNTIME=nodejs4.3
 
   while [ $# -ne 0 ]; do
     CODE=$1
@@ -183,6 +184,15 @@ function readFunctionConfigParams {
         shift
       else
         echo "readFunctionConfigParams: You must specify a memory limit in MiB for parameter $CODE" 1>&2
+        doHelp
+        exit -1
+      fi
+    elif [ "$CODE" == "--runtime" ]; then
+      if [ $# -ne 0 ]; then
+        RUNTIME=$1
+        shift
+      else
+        echo "readFunctionConfigParams: You must specify a runtime environment of the Lambda function for parameter $CODE" 1>&2
         doHelp
         exit -1
       fi
@@ -285,7 +295,7 @@ function deployFanout {
       fi
     fi
 
-    FUNCTION_ARN=$(aws lambda "create-function" --function-name $FUNCTION_NAME --runtime nodejs8.10 --description "This is an Amazon Kinesis and Amazon DynamoDB Streams fanout function, look at $TABLE_NAME DynamoDB table for configuration" --handler fanout.handler --role $EXEC_ROLE_ARN --memory-size $MEMORY_SIZE --timeout $TIMEOUT --zip-file fileb://fanout.zip ${VPC_PARAMS[@]} --query 'FunctionArn' --output text ${CLI_PARAMS[@]})
+    FUNCTION_ARN=$(aws lambda "create-function" --function-name $FUNCTION_NAME --runtime $RUNTIME --description "This is an Amazon Kinesis and Amazon DynamoDB Streams fanout function, look at $TABLE_NAME DynamoDB table for configuration" --handler fanout.handler --role $EXEC_ROLE_ARN --memory-size $MEMORY_SIZE --timeout $TIMEOUT --zip-file fileb://fanout.zip ${VPC_PARAMS[@]} --query 'FunctionArn' --output text ${CLI_PARAMS[@]})
     if [ -z "${FUNCTION_ARN}" ]; then
       echo "Unable to create specified AWS Lambda Function '${FUNCTION_NAME}'" 1>&2
       cd "$OLD"
@@ -294,6 +304,14 @@ function deployFanout {
     echo "Created AWS Lambda Function $FUNCTION_NAME with ARN: $FUNCTION_ARN"
   else
     FUNCTION_ARN=$(aws lambda update-function-code --function-name ${FUNCTION_NAME} --zip-file fileb://fanout.zip --query 'FunctionArn' --output text ${CLI_PARAMS[@]})
+    if [ -z "${FUNCTION_ARN}" ]; then
+      echo "Unable to update code of specified AWS Lambda Function '${FUNCTION_NAME}'" 1>&2
+      cd "$OLD"
+      exit -1
+    fi
+    echo "Updated code of AWS Lambda Function $FUNCTION_NAME with ARN: $FUNCTION_ARN"
+
+    FUNCTION_ARN=$(aws lambda update-function-configuration --function-name ${FUNCTION_NAME} --runtime $RUNTIME --query 'FunctionArn' --output text ${CLI_PARAMS[@]})
     if [ -z "${FUNCTION_ARN}" ]; then
       echo "Unable to update specified AWS Lambda Function '${FUNCTION_NAME}'" 1>&2
       cd "$OLD"

--- a/cli/functions.sh
+++ b/cli/functions.sh
@@ -313,6 +313,15 @@ function deployFanout {
     fi
     echo "Updated code of AWS Lambda Function $FUNCTION_NAME with ARN: $FUNCTION_ARN"
 
+    if [ -z "$EXEC_ROLE_ARN" ]; then
+      if [ -z "$EXEC_ROLE_NAME" ]; then
+        EXEC_ROLE_NAME=${FUNCTION_NAME}Role
+      fi
+
+      aws iam put-role-policy --role-name $EXEC_ROLE_NAME --policy-name Metrics --policy-document '{"Version": "2012-10-17", "Statement": [{"Action": ["cloudwatch:PutMetricData"], "Resource": ["*"], "Effect": "Allow", "Sid": ""}]}' ${CLI_PARAMS[@]}
+      echo "Updated IAM role $EXEC_ROLE_NAME with Metrics policy"
+    fi
+
     FUNCTION_ARN=$(aws lambda update-function-configuration --function-name ${FUNCTION_NAME} --runtime $RUNTIME --query 'FunctionArn' --output text ${CLI_PARAMS[@]})
     if [ -z "${FUNCTION_ARN}" ]; then
       echo "Unable to update specified AWS Lambda Function '${FUNCTION_NAME}'" 1>&2

--- a/cli/help.sh
+++ b/cli/help.sh
@@ -101,6 +101,7 @@ function helpObjectProperties {
   echo "  --parallel <flag>: processes multiple messages in parallel for efficiency" 1>&2
   echo "  --convert-ddb <flag>: for Amazon DynamoDB Streams messages, converts the DDB objects to plain JavaScript objects" 1>&2
   echo "  --deaggregate <flag>: for Amazon Kinesis Streams messages, deserializes KPL (protobuf-based) messages" 1>&2
+  echo "  --append-newlines <flag>: for Amazon DynamoDB Streams messages, append a newline to the end of each record" 1>&2
 }
 
 function helpTargetParams {

--- a/cli/targets.sh
+++ b/cli/targets.sh
@@ -281,6 +281,7 @@ function readObjectProperties {
   PARALLEL=
   CONVERT_DDB=
   DEAGGREGATE=
+  APPEND_NEWLINES=
 
   while [ $# -ne 0 ]; do
     CODE=$1
@@ -330,6 +331,15 @@ function readObjectProperties {
         doHelp
         exit -1
       fi
+    elif [ "$CODE" == "--append-newlines" ]; then
+      if [ $# -ne 0 ]; then
+        APPEND_NEWLINES=$1
+        shift
+      else
+        echo "readObjectProperties: You must specify a value for parameter $CODE" 1>&2
+        doHelp
+        exit -1
+      fi
     elif [[ "$CODE" =~ ^--.* ]]; then
       PASSTHROUGH+=($CODE)
       if [ $# -ne 0 ]; then
@@ -367,6 +377,11 @@ function readObjectProperties {
   fi
   if [ ! -z "${DEAGGREGATE}" ] && [ "${DEAGGREGATE}" != "true" ] && [ "${DEAGGREGATE}" != "false" ]; then
     echo "readObjectProperties: invalid boolean property --deaggregate $PARALLEL, must be one of (true, false)" 1>&2
+    doHelp
+    exit -1
+  fi
+  if [ ! -z "${APPEND_NEWLINES}" ] && [ "${APPEND_NEWLINES}" != "true" ] && [ "${APPEND_NEWLINES}" != "false" ]; then
+    echo "readObjectProperties: invalid boolean property --append-newlines $APPEND_NEWLINES, must be one of (true, false)" 1>&2
     doHelp
     exit -1
   fi
@@ -436,6 +451,9 @@ function buildObject {
   fi
   if [ ! -z "${DEAGGREGATE}" ]; then
     appendJsonProperty "$1" "deaggregate" "{\"BOOL\":${DEAGGREGATE}}"
+  fi
+  if [ ! -z "${APPEND_NEWLINES}" ]; then
+    appendJsonProperty "$1" "appendNewlines" "{\"BOOL\":${APPEND_NEWLINES}}"
   fi
 }
 

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -84,7 +84,7 @@ var roleRegex = /^arn:aws:iam::[0-9]{12}:role\/([a-zA-Z0-9+=,.@_-]{1,64})$/;
 var regionRegex = /^[a-z]+-[a-z]+-[0-9]$/;
 var externalIdRegex = /^[a-zA-Z0-9_+=,.@:\/-]{2,1024}$/;
 var collapseRegex = /^JSON|concat|none$/;
-var sourceRegex = /^arn:aws:((kinesis:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:stream\/([a-zA-Z0-9_-]{1,128}))|(dynamodb:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:table\/[A-Za-z0-9_.-]+\/stream\/[0-9A-Z_.:-]+))$/;
+var sourceRegex = /^arn:aws:((kinesis:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:stream\/([a-zA-Z0-9_.-]{1,128}))|(dynamodb:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:table\/[A-Za-z0-9_.-]+\/stream\/[0-9A-Z_.:-]+))$/;
 
 //********
 // This function reads an Amazon DynamoDB record and prepares the configuration entry

--- a/lib/ddb-utils.js
+++ b/lib/ddb-utils.js
@@ -97,7 +97,7 @@ function parseDynamoDBPropertyValue(value) {
       return value.BS.map(function(entry) {
         //return new Buffer(entry, 'base64');
         return entry; // Leave it as a base64 string for subsequent serialization
-        return new Buffer(entry, 'base64');
+        //return new Buffer(entry, 'base64');
       });
     }
     case "L": {

--- a/lib/post-es.js
+++ b/lib/post-es.js
@@ -91,7 +91,7 @@ exports.send = function(service, target, records, callback) {
 
   req.body = Buffer.concat(
       records.map(function(record) 
-        { return Buffer.concat([new Buffer('{"index":{"_id":"' + record.key + '"}}' + "\n", 'utf-8'), record.data, new Buffer("\n", 'utf-8')]); }));
+        { return Buffer.concat([Buffer.from('{"index":{"_id":"' + record.key + '"}}' + "\n", 'utf-8'), record.data, Buffer.from("\n", 'utf-8')]); }));
 
   var signer = new AWS.Signers.V4(req , 'es');
   signer.addAuthorization(service.credentials, new Date());

--- a/lib/post-firehose.js
+++ b/lib/post-firehose.js
@@ -57,7 +57,7 @@ exports.destinationRegex = /^([a-zA-Z0-9_-]{1,64})$/;
 //********
 // This function transforms a record form Kinesis based on the target configuration
 function textTransform(record, target) {
-  var data = new Buffer(record.kinesis.data, 'base64');
+  var data = Buffer.from(record.kinesis.data, 'base64');
   var size = data.length;
   try {
     data = JSON.parse(data.toString());

--- a/lib/post-kinesis.js
+++ b/lib/post-kinesis.js
@@ -75,24 +75,27 @@ exports.send = function(service, target, records, callback) {
 this.putRecordsWithRetry = function(service, request, callback)
 {
   var operation = retry.operation({
-    retries: 10,
-    factor: 2,
-    minTimeout: 10,
-    maxTimeout: 10000
+    retries: 20,
+    factor: 1.5,
+    minTimeout: 1000,
+    maxTimeout: 60000
   });
 
   operation.attempt(function(current) {
-    var response = service.putRecords(request, function() {
-      if (response && response.FailedRecordCount && response.FailedRecordCount == 0)
+    service.putRecords(request, function(awserr, response) {
+      if (response && response.FailedRecordCount === 0)
         return;
       if (response && response.Records)
       {
         var failed = response.Records.map(function(record) { return record.ErrorCode != null; } );
+        var firstFailed = response.Records.filter(function(record, index) { return failed[index]; })[0];
+        console.log("Kinesis PutRecords "+ response.FailedRecordCount +" of "+ request.Records.length +" failed ("+ firstFailed.ErrorCode +"). Retry #"+ current);
         request.Records = request.Records.filter(function(record, index) { return failed[index]; });
-        var err = new Error(response.Records[0].ErrorCode);
-        if (operation.retry())
+        var err = new Error(firstFailed.ErrorCode);
+        if (operation.retry(err))
           return;
       }
+      console.error("Kinesis PutRecords retries ("+ current +") exhausted", err);
       callback(err ? operation.mainError() : null);
     });
   });

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -49,7 +49,7 @@ function serialize(object) {
   } else if(typeof(object) == "string") {
     return "$" + Buffer.byteLength(object) + "\r\n" + object + "\r\n";
   } else if(Buffer.isBuffer(object)) {
-    return Buffer.concat([new Buffer("$" + object.length + "\r\n", 'utf-8'), object, new Buffer("\r\n", 'utf-8')]);
+    return Buffer.concat([Buffer.from("$" + object.length + "\r\n", 'utf-8'), object, Buffer.from("\r\n", 'utf-8')]);
   } else {
     throw new Error("Unsupported Redis command data type:", JSON.stringify(object));
   }

--- a/lib/statistics.js
+++ b/lib/statistics.js
@@ -58,14 +58,14 @@ exports.create = function() {
     if (source) {
       if (destination) {
         // Aggregation per source, destination and function
-        dimensions = [{ Name: "Source", Value: source }, { Name: "Destination", Value: source }, { Name: "Function", Value: process.env.AWS_LAMBDA_FUNCTION_NAME }];
+        dimensions = [{ Name: "Source", Value: source }, { Name: "Destination", Value: destination }, { Name: "Function", Value: process.env.AWS_LAMBDA_FUNCTION_NAME }];
       } else {
         // Aggregation per source and function
         dimensions = [{ Name: "Source", Value: source }, { Name: "Function", Value: process.env.AWS_LAMBDA_FUNCTION_NAME }];
       }
     } else if (destination) {
       // Aggregation per destination and function
-      dimensions = [{ Name: "Destination", Value: source }, { Name: "Function", Value: process.env.AWS_LAMBDA_FUNCTION_NAME }];
+      dimensions = [{ Name: "Destination", Value: destination }, { Name: "Function", Value: process.env.AWS_LAMBDA_FUNCTION_NAME }];
     } else {
       // Aggregation per function
       dimensions = [{ Name: "Function", Value: process.env.AWS_LAMBDA_FUNCTION_NAME }];

--- a/lib/statistics.js
+++ b/lib/statistics.js
@@ -89,10 +89,10 @@ exports.create = function() {
     var cwMetrics = [];
     Object.keys(metrics).forEach(function(key) {
       metric = metrics[key];
-      if(metrics.type == 'counter') {
-        cwMetrics.push({ MetricName: metric.name, Dimensions: metrics.dimensions, Unit: metric.unit, Timestamp: time, Value: entries[key] });
-      } else if(metrics.type == 'stats') {
-        cwMetrics.push({ MetricName: metric.name, Dimensions: metrics.dimensions, Unit: metric.unit, Timestamp: time, StatisticValues: entries[key] });
+      if(metric.type == 'counter') {
+        cwMetrics.push({ MetricName: metric.name, Dimensions: metric.dimensions, Unit: metric.unit, Timestamp: time, Value: entries[key] });
+      } else if(metric.type == 'stats') {
+        cwMetrics.push({ MetricName: metric.name, Dimensions: metric.dimensions, Unit: metric.unit, Timestamp: time, StatisticValues: entries[key] });
       }
     });
 
@@ -111,6 +111,7 @@ exports.create = function() {
         cwMetrics = cwMetrics.slice(20);
       } else {
         toSend = cwMetrics;
+        cwMetrics = [];
       }
 
       cloudWatch.putMetricData({ Namespace: config.cloudWatchNamespace, MetricData: toSend }, function(err, data) {
@@ -148,16 +149,16 @@ exports.create = function() {
     }
     var entry = entries[name];
     if(entry.SampleCount == 0) {
-      entry.Min = value;
-      entry.Max = value;
+      entry.Minimum = value;
+      entry.Maximum = value;
       entry.Sum = value;
       entry.SampleCount = 1;
     } else {
-      if(entry.Min > value) {
-        entry.Min = value;
+      if(entry.Minimum > value) {
+        entry.Minimum = value;
       }
-      if(entry.Max < value) {
-        entry.Max = value;
+      if(entry.Maximum < value) {
+        entry.Maximum = value;
       }
       entry.Sum += value;
       entry.SampleCount += 1;

--- a/lib/transformation.js
+++ b/lib/transformation.js
@@ -31,7 +31,7 @@ function transformDDBRecord(record, target, callback) {
   try {
     var entry = (record.dynamodb.hasOwnProperty("NewImage") ? record.dynamodb.NewImage : {});
     var object = target.convertDDB ? DDB.parseDynamoDBObject(entry) : entry;
-    var data = new Buffer(JSON.stringify(object), 'utf-8');
+    var data = Buffer.from(JSON.stringify(object), 'utf-8');
     var keys = Object.keys(record.dynamodb.Keys);
     var keyEntry = DDB.parseDynamoDBObject(record.dynamodb.Keys);
     var key = "";
@@ -64,7 +64,7 @@ function transformDDBRecord(record, target, callback) {
 // This function prepares a single Amazon Kinesis Stream record
 function transformKinesisSingleRecord(record, target, callback) {
   try {
-    var data = new Buffer(record.kinesis.data, 'base64');
+    var data = Buffer.from(record.kinesis.data, 'base64');
     callback(null, [{
       "key": record.kinesis.partitionKey,
       "sequenceNumber": record.kinesis.sequenceNumber,
@@ -108,7 +108,7 @@ function transformKinesisAggregatedRecords(record, target, callback) {
 // This function prepares an Amazon SNS record
 function transformSNSRecord(record, target, callback) {
   try {
-    var data = new Buffer(record.Sns.Message);
+    var data = Buffer.from(record.Sns.Message);
     callback(null, [{
       "key": record.Sns.MessageId,
       "sequenceNumber": record.Sns.Timestamp,

--- a/lib/transformation.js
+++ b/lib/transformation.js
@@ -31,7 +31,7 @@ function transformDDBRecord(record, target, callback) {
   try {
     var entry = (record.dynamodb.hasOwnProperty("NewImage") ? record.dynamodb.NewImage : {});
     var object = target.convertDDB ? DDB.parseDynamoDBObject(entry) : entry;
-    var data = Buffer.from(JSON.stringify(object) + (target.appendNewlines ? "\n" : '', 'utf-8');
+    var data = Buffer.from(JSON.stringify(object) + (target.appendNewlines ? "\n" : ''), 'utf-8');
     var keys = Object.keys(record.dynamodb.Keys);
     var keyEntry = DDB.parseDynamoDBObject(record.dynamodb.Keys);
     var key = "";

--- a/lib/transformation.js
+++ b/lib/transformation.js
@@ -93,7 +93,7 @@ function transformKinesisAggregatedRecords(record, target, callback) {
         transformKinesisSingleRecord({"kinesis": subRecord, "eventSource": record.eventSource, "region": record.region}, target, subRecordCallback);
       }, function(err, results) {
         if(err) {
-          console.error("Error occured while transforming KPL records:", e.stack);
+          console.error("Error occured while transforming KPL records:", err);
           callback(null, []);
         } else {
           // Flatten the structure

--- a/lib/transformation.js
+++ b/lib/transformation.js
@@ -31,7 +31,7 @@ function transformDDBRecord(record, target, callback) {
   try {
     var entry = (record.dynamodb.hasOwnProperty("NewImage") ? record.dynamodb.NewImage : {});
     var object = target.convertDDB ? DDB.parseDynamoDBObject(entry) : entry;
-    var data = new Buffer(JSON.stringify(object), 'utf-8');
+    var data = new Buffer(JSON.stringify(object) + (target.appendNewlines ? "\n" : ''), 'utf-8');
     var keys = Object.keys(record.dynamodb.Keys);
     var keyEntry = DDB.parseDynamoDBObject(record.dynamodb.Keys);
     var key = "";

--- a/test/ddb-utils.test.js
+++ b/test/ddb-utils.test.js
@@ -96,12 +96,12 @@ describe('ddb-utils', function() {
       assert.strictEqual(DDB.parseDynamoDBPropertyValue({ N: "-1000.1" }), -1000.1);
       assert.strictEqual(DDB.parseDynamoDBPropertyValue({ BOOL: true }), true);
       assert.strictEqual(DDB.parseDynamoDBPropertyValue({ BOOL: false }), false);
-      assert.strictEqual(DDB.parseDynamoDBPropertyValue({ B: "YjY0VmFs" }), new Buffer("b64Val").toString('base64'));
+      assert.strictEqual(DDB.parseDynamoDBPropertyValue({ B: "YjY0VmFs" }), Buffer.from("b64Val").toString('base64'));
     });
     it('should support SS, NS ans BS', function () {
       assert.deepStrictEqual(DDB.parseDynamoDBPropertyValue({ SS: [ "", "string1", "string2" ]}), [ "", "string1", "string2" ]);
       assert.deepStrictEqual(DDB.parseDynamoDBPropertyValue({ NS: [ "0", "1000.1", "-1000.1" ]}), [ 0, 1000.1, -1000.1 ]);
-      assert.deepStrictEqual(DDB.parseDynamoDBPropertyValue({ BS: [ "YjY0dmFs", "YjY0VmFs" ]}).map(function(t) { return t.toString() }), [ new Buffer("b64val").toString('base64'), new Buffer("b64Val").toString('base64') ]);
+      assert.deepStrictEqual(DDB.parseDynamoDBPropertyValue({ BS: [ "YjY0dmFs", "YjY0VmFs" ]}).map(function(t) { return t.toString() }), [ Buffer.from("b64val").toString('base64'), Buffer.from("b64Val").toString('base64') ]);
     });
     it('should support map and list', function () {
       assert.deepStrictEqual(DDB.parseDynamoDBPropertyValue({ M: { a: { NULL: true }, b: { S: "string1" }, c: { N: "1000.1" }, d: { BOOL: true } }}), { a: null, b: "string1", c: 1000.1, d: true });


### PR DESCRIPTION
Buffer.from() port to avoid deprecation warnings resulting in events lost before being posted to SNS, which started to get thrown with migration to AWS miminum support Node.js 10.x, which was forced in order to increase timeout and add memory:

(node:8) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

See https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

Also, merged in metrics (and other) fixes from original fork.

Fixed Kinesis put retry code (and added logging), which seemed to never have worked. Only first try events were getting fanned out from `il-rosterevents` to `il-events` streams. Tweaked retry/back-off options to resemble that of Roster Service and take full advantage of Lambda timeout (15 minutes) to retry if necessary. 100k student import test, showed only having to retry a batch at most 3 times.